### PR TITLE
feat(triggers): add log-only trigger type for schedule verification

### DIFF
--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -10,7 +10,7 @@ export function addCommand(): Command {
   return new Command("add")
     .description("Add a new schedule (wizard if no cron arg)")
     .argument("[cron]", "Cron expression")
-    .option("--trigger <type>", "Trigger type: claude-cli | claude-api | browser")
+    .option("--trigger <type>", "Trigger type: claude-cli | claude-api | browser | log")
     .option("--prompt-type <type>", "Prompt type: fixed | random | dynamic")
     .option("--prompt <text>", "Fixed prompt text")
     .option("--prompt-template <text>", "Dynamic prompt template")

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -4,7 +4,7 @@ const ScheduleEntrySchema = z.object({
   id: z.string().min(3).max(64).regex(/^[a-z0-9-]+$/),
   cron: z.string().min(1),
   enabled: z.boolean().default(true),
-  trigger: z.enum(["claude-cli", "claude-api", "browser"]),
+  trigger: z.enum(["claude-cli", "claude-api", "browser", "log"]),
   prompt_type: z.enum(["fixed", "random", "dynamic"]),
   prompt: z.string().optional(),
   prompt_template: z.string().optional(),

--- a/src/triggers/index.ts
+++ b/src/triggers/index.ts
@@ -2,6 +2,7 @@ import type { ScheduleEntry, Config } from "../config/schema"
 import { claudeCliTrigger } from "./claude-cli"
 import { claudeApiTrigger } from "./claude-api"
 import { browserTrigger } from "./browser"
+import { logTrigger } from "./log"
 
 export async function fireTrigger(
   schedule: ScheduleEntry,
@@ -27,5 +28,9 @@ export async function fireTrigger(
       await browserTrigger(url)
       break
     }
+
+    case "log":
+      await logTrigger(schedule.id, schedule.cron, prompt)
+      break
   }
 }

--- a/src/triggers/log.ts
+++ b/src/triggers/log.ts
@@ -1,0 +1,10 @@
+export async function logTrigger(scheduleId: string, cron: string, prompt: string | null): Promise<void> {
+  console.log(JSON.stringify({
+    level: "info",
+    time: new Date().toISOString(),
+    scheduleId,
+    cron,
+    prompt,
+    msg: "schedule fired (log-only)",
+  }))
+}

--- a/src/wizard/index.ts
+++ b/src/wizard/index.ts
@@ -11,6 +11,7 @@ export async function runWizard(config: Config): Promise<ScheduleEntry> {
       { value: "claude-cli", label: "Claude CLI (requires `claude` on PATH)" },
       { value: "claude-api", label: "Claude API (requires ANTHROPIC_API_KEY)" },
       { value: "browser",    label: "Browser (opens Claude.ai URL)" },
+      { value: "log",        label: "Log only (for testing — no Claude invoked)" },
     ],
   })
   if (p.isCancel(trigger)) { p.cancel("Cancelled"); process.exit(0) }

--- a/tests/triggers/log.test.ts
+++ b/tests/triggers/log.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, mock, afterEach } from "bun:test"
+
+describe("logTrigger", () => {
+  const originalLog = console.log
+
+  afterEach(() => {
+    console.log = originalLog
+  })
+
+  it("logs a structured JSON entry with all fields", async () => {
+    const logged: string[] = []
+    console.log = mock((msg: string) => { logged.push(msg) }) as typeof console.log
+
+    const { logTrigger } = await import("../../src/triggers/log")
+    await logTrigger("check-cron", "*/5 * * * *", "Heartbeat check")
+
+    expect(logged).toHaveLength(1)
+    const entry = JSON.parse(logged[0]!)
+    expect(entry.level).toBe("info")
+    expect(entry.scheduleId).toBe("check-cron")
+    expect(entry.cron).toBe("*/5 * * * *")
+    expect(entry.prompt).toBe("Heartbeat check")
+    expect(entry.msg).toBe("schedule fired (log-only)")
+    expect(typeof entry.time).toBe("string")
+  })
+
+  it("logs with null prompt", async () => {
+    const logged: string[] = []
+    console.log = mock((msg: string) => { logged.push(msg) }) as typeof console.log
+
+    const { logTrigger } = await import("../../src/triggers/log")
+    await logTrigger("check-cron", "0 9 * * 1-5", null)
+
+    const entry = JSON.parse(logged[0]!)
+    expect(entry.prompt).toBeNull()
+    expect(entry.scheduleId).toBe("check-cron")
+  })
+})


### PR DESCRIPTION
Introduces a new 'log' trigger that writes a structured JSON entry to stdout on each fire without invoking Claude or opening a browser, making it easy to verify cron timing before going live.