### PR TITLE
chore: add ESLint and Prettier for code formatting and linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,12 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.10",
+        "eslint": "^10.0.3",
+        "eslint-config-prettier": "^10.1.8",
+        "prettier": "^3.8.1",
+        "typescript-eslint": "^8.57.0",
       },
       "peerDependencies": {
         "typescript": "^5.9.3",
@@ -25,13 +30,73 @@
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.3", "", { "dependencies": { "@eslint/object-schema": "^3.0.3", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.3", "", { "dependencies": { "@eslint/core": "^1.1.1" } }, "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw=="],
+
+    "@eslint/core": ["@eslint/core@1.1.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.3", "", {}, "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
     "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/type-utils": "8.57.0", "@typescript-eslint/utils": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.57.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.0", "@typescript-eslint/types": "^8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.0", "", { "dependencies": { "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0" } }, "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.57.0", "", { "dependencies": { "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0", "@typescript-eslint/utils": "8.57.0", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.57.0", "", {}, "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.0", "@typescript-eslint/tsconfig-utils": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.0", "", { "dependencies": { "@typescript-eslint/types": "8.57.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
@@ -39,7 +104,91 @@
 
     "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.0.3", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.3", "@eslint/config-helpers": "^0.5.2", "@eslint/core": "^1.1.1", "@eslint/plugin-kit": "^0.6.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.1.1", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.1", "", {}, "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
 
@@ -47,13 +196,25 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -65,10 +226,30 @@
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.57.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.0", "@typescript-eslint/parser": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0", "@typescript-eslint/utils": "8.57.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import eslint from "@eslint/js"
+import tseslint from "typescript-eslint"
+import prettier from "eslint-config-prettier"
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  prettier,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
+  {
+    ignores: ["node_modules/**"],
+  }
+)

--- a/package.json
+++ b/package.json
@@ -10,10 +10,18 @@
     "start": "bun run src/cli/index.ts",
     "daemon": "bun run src/daemon/index.ts",
     "test": "bun test",
-    "lint": "bunx tsc --noEmit"
+    "format": "bunx prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format:check": "bunx prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "bunx tsc --noEmit && bunx eslint src tests",
+    "lint:fix": "bunx eslint --fix src tests"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.10"
+    "@eslint/js": "^10.0.1",
+    "@types/bun": "^1.3.10",
+    "eslint": "^10.0.3",
+    "eslint-config-prettier": "^10.1.8",
+    "prettier": "^3.8.1",
+    "typescript-eslint": "^8.57.0"
   },
   "peerDependencies": {
     "typescript": "^5.9.3"

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -22,14 +22,32 @@ export function addCommand(): Command {
       if (!cron) {
         entry = await runWizard(config)
       } else {
-        if (!opts.trigger) { console.error("--trigger is required"); process.exit(1) }
-        if (!opts.promptType) { console.error("--prompt-type is required"); process.exit(1) }
-        if (opts.promptType === "fixed" && !opts.prompt) { console.error("--prompt is required for fixed prompt-type"); process.exit(1) }
-        if (opts.promptType === "dynamic" && !opts.promptTemplate) { console.error("--prompt-template is required for dynamic prompt-type"); process.exit(1) }
+        if (!opts.trigger) {
+          console.error("--trigger is required")
+          process.exit(1)
+        }
+        if (!opts.promptType) {
+          console.error("--prompt-type is required")
+          process.exit(1)
+        }
+        if (opts.promptType === "fixed" && !opts.prompt) {
+          console.error("--prompt is required for fixed prompt-type")
+          process.exit(1)
+        }
+        if (opts.promptType === "dynamic" && !opts.promptTemplate) {
+          console.error("--prompt-template is required for dynamic prompt-type")
+          process.exit(1)
+        }
 
         const id = opts.id ?? generateId({ trigger: opts.trigger, cron }, config.schedules)
-        if (!validateId(id)) { console.error(`Invalid ID "${id}" — use lowercase alphanumeric and hyphens, 3-64 chars`); process.exit(1) }
-        if (config.schedules.find((s) => s.id === id)) { console.error(`Schedule ID "${id}" already exists`); process.exit(1) }
+        if (!validateId(id)) {
+          console.error(`Invalid ID "${id}" — use lowercase alphanumeric and hyphens, 3-64 chars`)
+          process.exit(1)
+        }
+        if (config.schedules.find((s) => s.id === id)) {
+          console.error(`Schedule ID "${id}" already exists`)
+          process.exit(1)
+        }
 
         entry = {
           id,
@@ -47,7 +65,11 @@ export function addCommand(): Command {
       console.log(`Schedule "${entry.id}" added.`)
 
       if (isDaemonRunning()) {
-        try { await sendIpcCommand({ command: "reload" }) } catch { /* daemon will reload on next start */ }
+        try {
+          await sendIpcCommand({ command: "reload" })
+        } catch {
+          /* daemon will reload on next start */
+        }
       }
     })
 }

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -6,17 +6,23 @@ import { stringify } from "smol-toml"
 export function configCommand(): Command {
   const cmd = new Command("config").description("Manage configuration")
 
-  cmd.command("show").description("Print current config").action(() => {
-    const config = readConfig()
-    console.log(stringify(config as Record<string, unknown>))
-  })
+  cmd
+    .command("show")
+    .description("Print current config")
+    .action(() => {
+      const config = readConfig()
+      console.log(stringify(config as Record<string, unknown>))
+    })
 
-  cmd.command("edit").description("Open config in $EDITOR").action(async () => {
-    const editor = process.env["EDITOR"] ?? (process.platform === "win32" ? "notepad" : "nano")
-    // Await exited so the CLI does not return to the shell mid-edit
-    const proc = Bun.spawn([editor, CONFIG_FILE], { stdio: ["inherit", "inherit", "inherit"] })
-    await proc.exited
-  })
+  cmd
+    .command("edit")
+    .description("Open config in $EDITOR")
+    .action(async () => {
+      const editor = process.env["EDITOR"] ?? (process.platform === "win32" ? "notepad" : "nano")
+      // Await exited so the CLI does not return to the shell mid-edit
+      const proc = Bun.spawn([editor, CONFIG_FILE], { stdio: ["inherit", "inherit", "inherit"] })
+      await proc.exited
+    })
 
   return cmd
 }

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -7,55 +7,93 @@ import { installAutostart, uninstallAutostart } from "../../daemon/autostart"
 export function daemonCommand(): Command {
   const cmd = new Command("daemon").description("Manage the climitless daemon")
 
-  cmd.command("start").description("Start the daemon").action(async () => {
-    if (isDaemonRunning()) { console.log("Daemon is already running."); return }
-    // Use import.meta.dir to resolve path relative to the CLI source file,
-    // not the user's current working directory.
-    const daemonScript = join(import.meta.dir, "..", "..", "daemon", "index.ts")
-    const proc = Bun.spawn(["bun", "run", daemonScript], {
-      detached: true,
-      stdio: ["ignore", "ignore", "ignore"],
+  cmd
+    .command("start")
+    .description("Start the daemon")
+    .action(async () => {
+      if (isDaemonRunning()) {
+        console.log("Daemon is already running.")
+        return
+      }
+      // Use import.meta.dir to resolve path relative to the CLI source file,
+      // not the user's current working directory.
+      const daemonScript = join(import.meta.dir, "..", "..", "daemon", "index.ts")
+      const proc = Bun.spawn(["bun", "run", daemonScript], {
+        detached: true,
+        stdio: ["ignore", "ignore", "ignore"],
+      })
+      proc.unref()
+      console.log("Daemon started.")
     })
-    proc.unref()
-    console.log("Daemon started.")
-  })
 
-  cmd.command("stop").description("Stop the daemon").action(async () => {
-    if (!isDaemonRunning()) { console.log("Daemon is not running."); return }
-    try {
-      await sendIpcCommand({ command: "stop" })
-      console.log("Daemon stopped.")
-    } catch { console.error("Could not reach daemon.") }
-  })
+  cmd
+    .command("stop")
+    .description("Stop the daemon")
+    .action(async () => {
+      if (!isDaemonRunning()) {
+        console.log("Daemon is not running.")
+        return
+      }
+      try {
+        await sendIpcCommand({ command: "stop" })
+        console.log("Daemon stopped.")
+      } catch {
+        console.error("Could not reach daemon.")
+      }
+    })
 
-  cmd.command("restart").description("Restart the daemon").action(async () => {
-    if (isDaemonRunning()) {
-      try { await sendIpcCommand({ command: "stop" }) } catch { /* ignore */ }
-    }
-    const daemonScript = join(import.meta.dir, "..", "..", "daemon", "index.ts")
-    const proc = Bun.spawn(["bun", "run", daemonScript], { detached: true, stdio: ["ignore", "ignore", "ignore"] })
-    proc.unref()
-    console.log("Daemon restarted.")
-  })
+  cmd
+    .command("restart")
+    .description("Restart the daemon")
+    .action(async () => {
+      if (isDaemonRunning()) {
+        try {
+          await sendIpcCommand({ command: "stop" })
+        } catch {
+          /* ignore */
+        }
+      }
+      const daemonScript = join(import.meta.dir, "..", "..", "daemon", "index.ts")
+      const proc = Bun.spawn(["bun", "run", daemonScript], {
+        detached: true,
+        stdio: ["ignore", "ignore", "ignore"],
+      })
+      proc.unref()
+      console.log("Daemon restarted.")
+    })
 
-  cmd.command("status").description("Show daemon status").action(async () => {
-    if (!isDaemonRunning()) { console.log("Daemon is not running."); return }
-    try {
-      const res = await sendIpcCommand({ command: "status" })
-      if (res.ok) console.log(JSON.stringify(res.data, null, 2))
-      else console.error(res.error)
-    } catch (err) { console.error(String(err)) }
-  })
+  cmd
+    .command("status")
+    .description("Show daemon status")
+    .action(async () => {
+      if (!isDaemonRunning()) {
+        console.log("Daemon is not running.")
+        return
+      }
+      try {
+        const res = await sendIpcCommand({ command: "status" })
+        if (res.ok) console.log(JSON.stringify(res.data, null, 2))
+        else console.error(res.error)
+      } catch (err) {
+        console.error(String(err))
+      }
+    })
 
-  cmd.command("install").description("Register daemon to auto-start on login").action(() => {
-    installAutostart()
-    console.log("Auto-start registered.")
-  })
+  cmd
+    .command("install")
+    .description("Register daemon to auto-start on login")
+    .action(() => {
+      installAutostart()
+      console.log("Auto-start registered.")
+    })
 
-  cmd.command("uninstall").description("Remove auto-start registration").action(() => {
-    uninstallAutostart()
-    console.log("Auto-start removed.")
-  })
+  cmd
+    .command("uninstall")
+    .description("Remove auto-start registration")
+    .action(() => {
+      uninstallAutostart()
+      console.log("Auto-start removed.")
+    })
 
   return cmd
 }

--- a/src/cli/commands/disable.ts
+++ b/src/cli/commands/disable.ts
@@ -10,10 +10,19 @@ export function disableCommand(): Command {
     .action(async (id: string) => {
       const config = readConfig()
       const schedule = config.schedules.find((s) => s.id === id)
-      if (!schedule) { console.error(`Schedule "${id}" not found`); process.exit(1) }
+      if (!schedule) {
+        console.error(`Schedule "${id}" not found`)
+        process.exit(1)
+      }
       schedule.enabled = false
       writeConfig(config)
       console.log(`Schedule "${id}" disabled.`)
-      if (isDaemonRunning()) { try { await sendIpcCommand({ command: "reload" }) } catch { /* ignore */ } }
+      if (isDaemonRunning()) {
+        try {
+          await sendIpcCommand({ command: "reload" })
+        } catch {
+          /* ignore */
+        }
+      }
     })
 }

--- a/src/cli/commands/enable.ts
+++ b/src/cli/commands/enable.ts
@@ -10,10 +10,19 @@ export function enableCommand(): Command {
     .action(async (id: string) => {
       const config = readConfig()
       const schedule = config.schedules.find((s) => s.id === id)
-      if (!schedule) { console.error(`Schedule "${id}" not found`); process.exit(1) }
+      if (!schedule) {
+        console.error(`Schedule "${id}" not found`)
+        process.exit(1)
+      }
       schedule.enabled = true
       writeConfig(config)
       console.log(`Schedule "${id}" enabled.`)
-      if (isDaemonRunning()) { try { await sendIpcCommand({ command: "reload" }) } catch { /* ignore */ } }
+      if (isDaemonRunning()) {
+        try {
+          await sendIpcCommand({ command: "reload" })
+        } catch {
+          /* ignore */
+        }
+      }
     })
 }

--- a/src/cli/commands/fire.ts
+++ b/src/cli/commands/fire.ts
@@ -13,7 +13,10 @@ export function fireCommand(): Command {
     .action(async (id: string, opts) => {
       const config = readConfig()
       const schedule = config.schedules.find((s) => s.id === id)
-      if (!schedule) { console.error(`Schedule "${id}" not found`); process.exit(1) }
+      if (!schedule) {
+        console.error(`Schedule "${id}" not found`)
+        process.exit(1)
+      }
 
       const prompt = buildPrompt(schedule, config.prompts.pool)
 
@@ -28,9 +31,16 @@ export function fireCommand(): Command {
       if (isDaemonRunning()) {
         try {
           const res = await sendIpcCommand({ command: "fire", scheduleId: id })
-          if (res.ok) { console.log(`Schedule "${id}" fired.`); return }
-          else { console.error(res.error); process.exit(1) }
-        } catch { /* fall through to direct fire */ }
+          if (res.ok) {
+            console.log(`Schedule "${id}" fired.`)
+            return
+          } else {
+            console.error(res.error)
+            process.exit(1)
+          }
+        } catch {
+          /* fall through to direct fire */
+        }
       }
 
       await fireTrigger(schedule, prompt, config)

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -4,29 +4,34 @@ import { sendIpcCommand } from "../../daemon/ipc"
 import { isDaemonRunning } from "../../daemon/lifecycle"
 
 export function listCommand(): Command {
-  return new Command("list")
-    .description("List all schedules")
-    .action(async () => {
-      const config = readConfig()
-      if (config.schedules.length === 0) { console.log("No schedules configured."); return }
+  return new Command("list").description("List all schedules").action(async () => {
+    const config = readConfig()
+    if (config.schedules.length === 0) {
+      console.log("No schedules configured.")
+      return
+    }
 
-      let nextFires: Record<string, string | null> = {}
-      if (isDaemonRunning()) {
-        try {
-          const res = await sendIpcCommand({ command: "status" })
-          if (res.ok) {
-            const data = res.data as { schedules: Array<{ id: string; nextFire: string | null }> }
-            nextFires = Object.fromEntries(data.schedules.map((s) => [s.id, s.nextFire]))
-          }
-        } catch { /* ignore */ }
+    let nextFires: Record<string, string | null> = {}
+    if (isDaemonRunning()) {
+      try {
+        const res = await sendIpcCommand({ command: "status" })
+        if (res.ok) {
+          const data = res.data as { schedules: Array<{ id: string; nextFire: string | null }> }
+          nextFires = Object.fromEntries(data.schedules.map((s) => [s.id, s.nextFire]))
+        }
+      } catch {
+        /* ignore */
       }
+    }
 
-      console.log("\nSchedules:\n")
-      for (const s of config.schedules) {
-        const status = s.enabled ? "✓" : "✗"
-        const next = nextFires[s.id] ? `  next: ${nextFires[s.id]}` : ""
-        console.log(`  [${status}] ${s.id}  (${s.cron})  trigger: ${s.trigger}  prompt: ${s.prompt_type}${next}`)
-      }
-      console.log()
-    })
+    console.log("\nSchedules:\n")
+    for (const s of config.schedules) {
+      const status = s.enabled ? "✓" : "✗"
+      const next = nextFires[s.id] ? `  next: ${nextFires[s.id]}` : ""
+      console.log(
+        `  [${status}] ${s.id}  (${s.cron})  trigger: ${s.trigger}  prompt: ${s.prompt_type}${next}`
+      )
+    }
+    console.log()
+  })
 }

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -11,7 +11,11 @@ export function logsCommand(): Command {
     .option("--schedule <id>", "Filter to a specific schedule")
     .option("--clear", "Clear all logs")
     .action((opts) => {
-      if (opts.clear) { clearLogs(); console.log("Logs cleared."); return }
+      if (opts.clear) {
+        clearLogs()
+        console.log("Logs cleared.")
+        return
+      }
 
       const lines = readLogs({ lines: parseInt(opts.lines, 10), scheduleId: opts.schedule })
       lines.forEach((l) => console.log(l))

--- a/src/cli/commands/prompts.ts
+++ b/src/cli/commands/prompts.ts
@@ -4,13 +4,20 @@ import { readConfig, writeConfig } from "../../config/index"
 export function promptsCommand(): Command {
   const cmd = new Command("prompts").description("Manage the random prompt pool")
 
-  cmd.command("list").description("List all prompts in the pool").action(() => {
-    const config = readConfig()
-    if (config.prompts.pool.length === 0) { console.log("Pool is empty."); return }
-    config.prompts.pool.forEach((p, i) => console.log(`  [${i}] ${p}`))
-  })
+  cmd
+    .command("list")
+    .description("List all prompts in the pool")
+    .action(() => {
+      const config = readConfig()
+      if (config.prompts.pool.length === 0) {
+        console.log("Pool is empty.")
+        return
+      }
+      config.prompts.pool.forEach((p, i) => console.log(`  [${i}] ${p}`))
+    })
 
-  cmd.command("add")
+  cmd
+    .command("add")
     .description("Add a prompt to the pool")
     .argument("<prompt>", "Prompt text")
     .action((prompt: string) => {
@@ -20,7 +27,8 @@ export function promptsCommand(): Command {
       console.log("Prompt added to pool.")
     })
 
-  cmd.command("remove")
+  cmd
+    .command("remove")
     .description("Remove a prompt by index")
     .argument("<index>", "Index from prompts list")
     .action((indexStr: string) => {

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -11,14 +11,20 @@ export function removeCommand(): Command {
       const config = readConfig()
       const idx = config.schedules.findIndex((s) => s.id === id)
       if (idx === -1) {
-        console.error(`Schedule "${id}" not found. Valid IDs: ${config.schedules.map((s) => s.id).join(", ")}`)
+        console.error(
+          `Schedule "${id}" not found. Valid IDs: ${config.schedules.map((s) => s.id).join(", ")}`
+        )
         process.exit(1)
       }
       config.schedules.splice(idx, 1)
       writeConfig(config)
       console.log(`Schedule "${id}" removed.`)
       if (isDaemonRunning()) {
-        try { await sendIpcCommand({ command: "reload" }) } catch { /* ignore */ }
+        try {
+          await sendIpcCommand({ command: "reload" })
+        } catch {
+          /* ignore */
+        }
       }
     })
 }

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -11,7 +11,11 @@ export function uninstallCommand(): Command {
     .option("--purge", "Also delete config, logs, and all user data")
     .action(async (opts) => {
       if (isDaemonRunning()) {
-        try { await sendIpcCommand({ command: "stop" }) } catch { /* ignore */ }
+        try {
+          await sendIpcCommand({ command: "stop" })
+        } catch {
+          /* ignore */
+        }
       }
       uninstallAutostart()
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,7 +12,11 @@ export function ensureDirs(): void {
 
 function applyPermissions(filePath: string): void {
   if (process.platform !== "win32") {
-    try { chmodSync(filePath, 0o600) } catch { /* ignore */ }
+    try {
+      chmodSync(filePath, 0o600)
+    } catch {
+      /* ignore */
+    }
   }
 }
 
@@ -40,7 +44,10 @@ export function loadEnvFile(): void {
     const eqIdx = trimmed.indexOf("=")
     if (eqIdx === -1) continue
     const key = trimmed.slice(0, eqIdx).trim()
-    const val = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, "")
+    const val = trimmed
+      .slice(eqIdx + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "")
     if (key && !(key in process.env)) process.env[key] = val
   }
 }

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -10,6 +10,4 @@ export const PID_FILE = join(CONFIG_DIR, "daemon.pid")
 
 // Platform-appropriate IPC path
 export const SOCKET_PATH =
-  process.platform === "win32"
-    ? "\\\\.\\pipe\\climitless"
-    : join(CONFIG_DIR, "daemon.sock")
+  process.platform === "win32" ? "\\\\.\\pipe\\climitless" : join(CONFIG_DIR, "daemon.sock")

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,7 +1,11 @@
 import { z } from "zod"
 
 const ScheduleEntrySchema = z.object({
-  id: z.string().min(3).max(64).regex(/^[a-z0-9-]+$/),
+  id: z
+    .string()
+    .min(3)
+    .max(64)
+    .regex(/^[a-z0-9-]+$/),
   cron: z.string().min(1),
   enabled: z.boolean().default(true),
   trigger: z.enum(["claude-cli", "claude-api", "browser", "log"]),

--- a/src/daemon/autostart.ts
+++ b/src/daemon/autostart.ts
@@ -30,7 +30,9 @@ export function installAutostart(): void {
     execSync("systemctl --user enable climitless.service")
     execSync("systemctl --user start climitless.service")
   } else if (process.platform === "win32") {
-    execSync(`reg add "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" /v climitless /t REG_SZ /d "${DAEMON_CMD}" /f`)
+    execSync(
+      `reg add "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" /v climitless /t REG_SZ /d "${DAEMON_CMD}" /f`
+    )
   }
 }
 
@@ -38,15 +40,33 @@ export function uninstallAutostart(): void {
   if (process.platform === "darwin") {
     const plistPath = join(homedir(), "Library/LaunchAgents/com.climitless.daemon.plist")
     if (existsSync(plistPath)) {
-      try { execSync(`launchctl unload "${plistPath}"`) } catch { /* ignore */ }
+      try {
+        execSync(`launchctl unload "${plistPath}"`)
+      } catch {
+        /* ignore */
+      }
       unlinkSync(plistPath)
     }
   } else if (process.platform === "linux") {
-    try { execSync("systemctl --user disable climitless.service") } catch { /* ignore */ }
-    try { execSync("systemctl --user stop climitless.service") } catch { /* ignore */ }
+    try {
+      execSync("systemctl --user disable climitless.service")
+    } catch {
+      /* ignore */
+    }
+    try {
+      execSync("systemctl --user stop climitless.service")
+    } catch {
+      /* ignore */
+    }
     const path = join(homedir(), ".config/systemd/user/climitless.service")
     if (existsSync(path)) unlinkSync(path)
   } else if (process.platform === "win32") {
-    try { execSync(`reg delete "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" /v climitless /f`) } catch { /* ignore */ }
+    try {
+      execSync(
+        `reg delete "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" /v climitless /f`
+      )
+    } catch {
+      /* ignore */
+    }
   }
 }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -13,10 +13,7 @@ loadEnvFile()
 
 let config = readConfig()
 
-const logger = pino(
-  { level: config.daemon.log_level },
-  pino.destination(LOG_FILE)
-)
+const logger = pino({ level: config.daemon.log_level }, pino.destination(LOG_FILE))
 
 const scheduler = new SchedulerManager()
 
@@ -44,11 +41,13 @@ const ipcServer = createIpcServer({
   status: async () => ({
     running: true,
     pid: process.pid,
-    schedules: config.schedules.filter((s) => s.enabled).map((s) => ({
-      id: s.id,
-      cron: s.cron,
-      nextFire: scheduler.nextFire(s.id)?.toISOString() ?? null,
-    })),
+    schedules: config.schedules
+      .filter((s) => s.enabled)
+      .map((s) => ({
+        id: s.id,
+        cron: s.cron,
+        nextFire: scheduler.nextFire(s.id)?.toISOString() ?? null,
+      })),
   }),
   reload: async () => {
     registerAllSchedules()
@@ -71,5 +70,15 @@ const ipcServer = createIpcServer({
 
 logger.info({ pid: process.pid }, "climitless daemon started")
 
-process.on("SIGINT", () => { scheduler.stopAll(); ipcServer.stop(); clearPid(); process.exit(0) })
-process.on("SIGTERM", () => { scheduler.stopAll(); ipcServer.stop(); clearPid(); process.exit(0) })
+process.on("SIGINT", () => {
+  scheduler.stopAll()
+  ipcServer.stop()
+  clearPid()
+  process.exit(0)
+})
+process.on("SIGTERM", () => {
+  scheduler.stopAll()
+  ipcServer.stop()
+  clearPid()
+  process.exit(0)
+})

--- a/src/daemon/ipc.ts
+++ b/src/daemon/ipc.ts
@@ -37,7 +37,8 @@ export function createIpcServer(handlers: IpcHandlers): { stop: () => void; read
       let buf = ""
       socket.on("data", async (chunk) => {
         buf += chunk.toString()
-        const lines = buf.split("\n"); buf = lines.pop() ?? ""
+        const lines = buf.split("\n")
+        buf = lines.pop() ?? ""
         for (const line of lines) {
           if (!line.trim()) continue
           const res = await handleLine(line, handlers)
@@ -53,17 +54,26 @@ export function createIpcServer(handlers: IpcHandlers): { stop: () => void; read
         resolve()
       })
     })
-    return { ready, stop() { server.close(); if (existsSync(PORT_FILE)) unlinkSync(PORT_FILE) } }
+    return {
+      ready,
+      stop() {
+        server.close()
+        if (existsSync(PORT_FILE)) unlinkSync(PORT_FILE)
+      },
+    }
   } else {
     // Unix: AF_UNIX socket
     if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH)
     const server = Bun.listen<{ buf: string }>({
       unix: SOCKET_PATH,
       socket: {
-        open(s) { s.data = { buf: "" } },
+        open(s) {
+          s.data = { buf: "" }
+        },
         async data(s, data) {
           s.data.buf += new TextDecoder().decode(data)
-          const lines = s.data.buf.split("\n"); s.data.buf = lines.pop() ?? ""
+          const lines = s.data.buf.split("\n")
+          s.data.buf = lines.pop() ?? ""
           for (const line of lines) {
             if (!line.trim()) continue
             const res = await handleLine(line, handlers)
@@ -74,38 +84,59 @@ export function createIpcServer(handlers: IpcHandlers): { stop: () => void; read
     })
     return {
       ready: Promise.resolve(),
-      stop() { server.stop(); if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH) },
+      stop() {
+        server.stop()
+        if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH)
+      },
     }
   }
 }
 
 export async function sendIpcCommand(req: IpcRequest, timeoutMs = 5000): Promise<IpcResponse> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("IPC timeout — is the daemon running?")), timeoutMs)
+    const timer = setTimeout(
+      () => reject(new Error("IPC timeout — is the daemon running?")),
+      timeoutMs
+    )
     let buf = ""
 
     let socket: ReturnType<typeof createConnection>
 
     if (IS_WIN) {
-      if (!existsSync(PORT_FILE)) { clearTimeout(timer); reject(new Error("Daemon is not running")); return }
+      if (!existsSync(PORT_FILE)) {
+        clearTimeout(timer)
+        reject(new Error("Daemon is not running"))
+        return
+      }
       const port = parseInt(readFileSync(PORT_FILE, "utf-8").trim(), 10)
       socket = createConnection({ host: "127.0.0.1", port })
     } else {
-      if (!existsSync(SOCKET_PATH)) { clearTimeout(timer); reject(new Error("Daemon is not running")); return }
+      if (!existsSync(SOCKET_PATH)) {
+        clearTimeout(timer)
+        reject(new Error("Daemon is not running"))
+        return
+      }
       socket = createConnection({ path: SOCKET_PATH })
     }
 
     socket.on("connect", () => socket.write(JSON.stringify(req) + "\n"))
     socket.on("data", (chunk) => {
       buf += chunk.toString()
-      const lines = buf.split("\n"); buf = lines.pop() ?? ""
+      const lines = buf.split("\n")
+      buf = lines.pop() ?? ""
       for (const line of lines) {
         if (!line.trim()) continue
         clearTimeout(timer)
-        try { resolve(JSON.parse(line) as IpcResponse) }
-        catch { reject(new Error("Invalid IPC response")) }
+        try {
+          resolve(JSON.parse(line) as IpcResponse)
+        } catch {
+          reject(new Error("Invalid IPC response"))
+        }
       }
     })
-    socket.on("error", (err) => { clearTimeout(timer); reject(err) })
+    socket.on("error", (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
   })
 }

--- a/src/logs/index.ts
+++ b/src/logs/index.ts
@@ -11,7 +11,12 @@ export interface LogEntry {
 }
 
 const LEVEL_LABELS: Record<number, string> = {
-  10: "TRACE", 20: "DEBUG", 30: "INFO", 40: "WARN", 50: "ERROR", 60: "FATAL"
+  10: "TRACE",
+  20: "DEBUG",
+  30: "INFO",
+  40: "WARN",
+  50: "ERROR",
+  60: "FATAL",
 }
 
 function formatEntry(entry: LogEntry): string {
@@ -27,12 +32,20 @@ function parseEntries(scheduleId?: string): LogEntry[] {
     .trim()
     .split("\n")
     .filter((l) => l.trim())
-    .map((l) => { try { return JSON.parse(l) as LogEntry } catch { return null } })
+    .map((l) => {
+      try {
+        return JSON.parse(l) as LogEntry
+      } catch {
+        return null
+      }
+    })
     .filter((e): e is LogEntry => e !== null)
     .filter((e) => !scheduleId || e.scheduleId === scheduleId)
 }
 
-export function readLogs(opts: { lines?: number; scheduleId?: string; offsetLines?: number } = {}): string[] {
+export function readLogs(
+  opts: { lines?: number; scheduleId?: string; offsetLines?: number } = {}
+): string[] {
   const entries = parseEntries(opts.scheduleId)
   const sliced = opts.offsetLines ? entries.slice(opts.offsetLines) : entries
   const limited = opts.lines ? sliced.slice(-opts.lines) : sliced.slice(-50)

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -1,7 +1,14 @@
 export interface NotificationAdapter {
-  notify(event: { scheduleId: string; trigger: string; success: boolean; message?: string }): Promise<void>
+  notify(event: {
+    scheduleId: string
+    trigger: string
+    success: boolean
+    message?: string
+  }): Promise<void>
 }
 
 export class NoopAdapter implements NotificationAdapter {
-  async notify(): Promise<void> { /* no-op in v1 */ }
+  async notify(): Promise<void> {
+    /* no-op in v1 */
+  }
 }

--- a/src/prompts/dynamic.ts
+++ b/src/prompts/dynamic.ts
@@ -1,9 +1,6 @@
-const DAYS = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
-export function buildDynamic(
-  template: string | undefined,
-  ctx: { scheduleId: string }
-): string {
+export function buildDynamic(template: string | undefined, ctx: { scheduleId: string }): string {
   if (!template) throw new Error("dynamic prompt requires a 'prompt_template' field")
   const now = new Date()
   const date = now.toISOString().slice(0, 10)

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -5,9 +5,13 @@ import { buildDynamic } from "./dynamic"
 
 export function buildPrompt(schedule: ScheduleEntry, pool: string[]): string | null {
   switch (schedule.prompt_type) {
-    case "fixed":   return buildFixed(schedule.prompt)
-    case "random":  return buildRandom(pool)
-    case "dynamic": return buildDynamic(schedule.prompt_template, { scheduleId: schedule.id })
-    default: return null
+    case "fixed":
+      return buildFixed(schedule.prompt)
+    case "random":
+      return buildRandom(pool)
+    case "dynamic":
+      return buildDynamic(schedule.prompt_template, { scheduleId: schedule.id })
+    default:
+      return null
   }
 }

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -16,7 +16,10 @@ export class SchedulerManager {
 
   unregister(id: string): void {
     const job = this.jobs.get(id)
-    if (job) { job.stop(); this.jobs.delete(id) }
+    if (job) {
+      job.stop()
+      this.jobs.delete(id)
+    }
   }
 
   isRegistered(id: string): boolean {
@@ -33,5 +36,7 @@ export class SchedulerManager {
   }
 
   /** Alias used in tests */
-  stop(): void { this.stopAll() }
+  stop(): void {
+    this.stopAll()
+  }
 }

--- a/src/triggers/claude-api.ts
+++ b/src/triggers/claude-api.ts
@@ -7,7 +7,8 @@ export async function claudeApiTrigger(
   config: ClaudeApiTriggerConfig
 ): Promise<void> {
   const apiKey = process.env[config.api_key_env]
-  if (!apiKey) throw new Error(`Env var ${config.api_key_env} is not set — cannot fire claude-api trigger`)
+  if (!apiKey)
+    throw new Error(`Env var ${config.api_key_env} is not set — cannot fire claude-api trigger`)
 
   const response = await fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",

--- a/src/triggers/index.ts
+++ b/src/triggers/index.ts
@@ -17,13 +17,21 @@ export async function fireTrigger(
 
     case "claude-api":
       if (!prompt) throw new Error("claude-api trigger requires a prompt")
-      await claudeApiTrigger(prompt, config.triggers.claude_api ?? { api_key_env: "ANTHROPIC_API_KEY", model: "claude-sonnet-4-6" })
+      await claudeApiTrigger(
+        prompt,
+        config.triggers.claude_api ?? {
+          api_key_env: "ANTHROPIC_API_KEY",
+          model: "claude-sonnet-4-6",
+        }
+      )
       break
 
     case "browser": {
       const url = config.triggers.browser?.url ?? "https://claude.ai"
       if (schedule.prompt_type === "fixed" || schedule.prompt_type === "dynamic") {
-        console.warn(`[climitless] Warning: schedule "${schedule.id}" has prompt_type "${schedule.prompt_type}" but uses browser trigger — the prompt is not sent to the browser`)
+        console.warn(
+          `[climitless] Warning: schedule "${schedule.id}" has prompt_type "${schedule.prompt_type}" but uses browser trigger — the prompt is not sent to the browser`
+        )
       }
       await browserTrigger(url)
       break

--- a/src/triggers/log.ts
+++ b/src/triggers/log.ts
@@ -1,10 +1,16 @@
-export async function logTrigger(scheduleId: string, cron: string, prompt: string | null): Promise<void> {
-  console.log(JSON.stringify({
-    level: "info",
-    time: new Date().toISOString(),
-    scheduleId,
-    cron,
-    prompt,
-    msg: "schedule fired (log-only)",
-  }))
+export async function logTrigger(
+  scheduleId: string,
+  cron: string,
+  prompt: string | null
+): Promise<void> {
+  console.log(
+    JSON.stringify({
+      level: "info",
+      time: new Date().toISOString(),
+      scheduleId,
+      cron,
+      prompt,
+      msg: "schedule fired (log-only)",
+    })
+  )
 }

--- a/src/wizard/index.ts
+++ b/src/wizard/index.ts
@@ -10,66 +10,99 @@ export async function runWizard(config: Config): Promise<ScheduleEntry> {
     options: [
       { value: "claude-cli", label: "Claude CLI (requires `claude` on PATH)" },
       { value: "claude-api", label: "Claude API (requires ANTHROPIC_API_KEY)" },
-      { value: "browser",    label: "Browser (opens Claude.ai URL)" },
-      { value: "log",        label: "Log only (for testing — no Claude invoked)" },
+      { value: "browser", label: "Browser (opens Claude.ai URL)" },
+      { value: "log", label: "Log only (for testing — no Claude invoked)" },
     ],
   })
-  if (p.isCancel(trigger)) { p.cancel("Cancelled"); process.exit(0) }
+  if (p.isCancel(trigger)) {
+    p.cancel("Cancelled")
+    process.exit(0)
+  }
 
   const scheduleMode = await p.select<string>({
     message: "How would you like to set the schedule?",
     options: [
       { value: "simple", label: "Simple time (e.g. 04:00 daily)" },
-      { value: "cron",   label: "Cron expression (advanced)" },
+      { value: "cron", label: "Cron expression (advanced)" },
     ],
   })
-  if (p.isCancel(scheduleMode)) { p.cancel("Cancelled"); process.exit(0) }
+  if (p.isCancel(scheduleMode)) {
+    p.cancel("Cancelled")
+    process.exit(0)
+  }
 
   let cron: string
   if (scheduleMode === "simple") {
     const time = await p.text({
       message: "Enter time (HH:MM)",
       placeholder: "04:00",
-      validate: (v) => /^\d{1,2}:\d{2}$/.test(v) ? undefined : "Please enter a valid time in HH:MM format (e.g. 04:00)",
+      validate: (v) =>
+        /^\d{1,2}:\d{2}$/.test(v)
+          ? undefined
+          : "Please enter a valid time in HH:MM format (e.g. 04:00)",
     })
-    if (p.isCancel(time)) { p.cancel("Cancelled"); process.exit(0) }
+    if (p.isCancel(time)) {
+      p.cancel("Cancelled")
+      process.exit(0)
+    }
     const [hh, mm] = (time as string).split(":")
     const recurrence = await p.select<string>({
       message: "Recurrence",
       options: [
-        { value: "daily",    label: "Every day" },
+        { value: "daily", label: "Every day" },
         { value: "weekdays", label: "Weekdays only (Mon-Fri)" },
-        { value: "once",     label: "One-shot (runs once, then you remove it)" },
+        { value: "once", label: "One-shot (runs once, then you remove it)" },
       ],
     })
-    if (p.isCancel(recurrence)) { p.cancel("Cancelled"); process.exit(0) }
+    if (p.isCancel(recurrence)) {
+      p.cancel("Cancelled")
+      process.exit(0)
+    }
     const days = recurrence === "weekdays" ? "1-5" : "*"
     cron = `${mm || "0"} ${hh || "0"} * * ${days}`
   } else {
     const cronRaw = await p.text({ message: "Enter cron expression", placeholder: "0 4 * * 1-5" })
-    if (p.isCancel(cronRaw)) { p.cancel("Cancelled"); process.exit(0) }
+    if (p.isCancel(cronRaw)) {
+      p.cancel("Cancelled")
+      process.exit(0)
+    }
     cron = cronRaw as string
   }
 
   const promptType = await p.select<string>({
     message: "Prompt type",
     options: [
-      { value: "fixed",   label: "Fixed — always the same message" },
-      { value: "random",  label: "Random — pick from your prompt pool" },
+      { value: "fixed", label: "Fixed — always the same message" },
+      { value: "random", label: "Random — pick from your prompt pool" },
       { value: "dynamic", label: "Dynamic — template with {{date}}, {{day_of_week}}, etc." },
     ],
   })
-  if (p.isCancel(promptType)) { p.cancel("Cancelled"); process.exit(0) }
+  if (p.isCancel(promptType)) {
+    p.cancel("Cancelled")
+    process.exit(0)
+  }
 
   let promptValue: string | undefined
   let promptTemplate: string | undefined
   if (promptType === "fixed") {
-    const txt = await p.text({ message: "Enter your prompt", placeholder: "Start a new work session." })
-    if (p.isCancel(txt)) { p.cancel("Cancelled"); process.exit(0) }
+    const txt = await p.text({
+      message: "Enter your prompt",
+      placeholder: "Start a new work session.",
+    })
+    if (p.isCancel(txt)) {
+      p.cancel("Cancelled")
+      process.exit(0)
+    }
     promptValue = txt as string
   } else if (promptType === "dynamic") {
-    const tpl = await p.text({ message: "Enter prompt template", placeholder: "Session on {{day_of_week}} {{date}}." })
-    if (p.isCancel(tpl)) { p.cancel("Cancelled"); process.exit(0) }
+    const tpl = await p.text({
+      message: "Enter prompt template",
+      placeholder: "Session on {{day_of_week}} {{date}}.",
+    })
+    if (p.isCancel(tpl)) {
+      p.cancel("Cancelled")
+      process.exit(0)
+    }
     promptTemplate = tpl as string
   }
 
@@ -78,14 +111,23 @@ export async function runWizard(config: Config): Promise<ScheduleEntry> {
     message: "Schedule ID (leave blank to auto-generate)",
     placeholder: autoId,
   })
-  if (p.isCancel(idRaw)) { p.cancel("Cancelled"); process.exit(0) }
+  if (p.isCancel(idRaw)) {
+    p.cancel("Cancelled")
+    process.exit(0)
+  }
   const id = (idRaw as string).trim() || autoId
-  if (!validateId(id)) { p.cancel(`Invalid ID "${id}"`); process.exit(1) }
+  if (!validateId(id)) {
+    p.cancel(`Invalid ID "${id}"`)
+    process.exit(1)
+  }
 
   const confirm = await p.confirm({
     message: `Add schedule "${id}" → ${trigger} at "${cron}"?`,
   })
-  if (p.isCancel(confirm) || !confirm) { p.cancel("Cancelled"); process.exit(0) }
+  if (p.isCancel(confirm) || !confirm) {
+    p.cancel("Cancelled")
+    process.exit(0)
+  }
 
   p.outro(`Schedule "${id}" ready to save.`)
 

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -42,7 +42,9 @@ describe("ConfigSchema", () => {
     const raw = {
       version: 1,
       daemon: { auto_reload: true, log_level: "info" },
-      schedules: [{ id: "test", cron: "0 4 * * *", enabled: true, trigger: "unknown", prompt_type: "fixed" }],
+      schedules: [
+        { id: "test", cron: "0 4 * * *", enabled: true, trigger: "unknown", prompt_type: "fixed" },
+      ],
       prompts: { pool: [] },
       triggers: {},
       notifications: { enabled: false },

--- a/tests/prompts/dynamic.test.ts
+++ b/tests/prompts/dynamic.test.ts
@@ -18,7 +18,7 @@ describe("buildDynamic", () => {
   })
 
   it("replaces {{day_of_week}}", () => {
-    const days = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"]
+    const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
     const result = buildDynamic("Day: {{day_of_week}}", { scheduleId: "x" })
     expect(days.some((d) => result.includes(d))).toBe(true)
   })

--- a/tests/scheduler/index.test.ts
+++ b/tests/scheduler/index.test.ts
@@ -30,7 +30,10 @@ describe("SchedulerManager", () => {
 
   it("unregisters a schedule", () => {
     const sm = new SchedulerManager()
-    sm.register(entry, mock(async () => {}))
+    sm.register(
+      entry,
+      mock(async () => {})
+    )
     sm.unregister("test")
     expect(sm.isRegistered("test")).toBe(false)
     sm.stop()

--- a/tests/triggers/claude-api.test.ts
+++ b/tests/triggers/claude-api.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it, mock } from "bun:test"
 
 describe("claudeApiTrigger", () => {
   it("calls Anthropic API with correct body", async () => {
-    const mockFetch = mock(async () =>
-      new Response(JSON.stringify({ id: "msg_1" }), { status: 200 })
+    const mockFetch = mock(
+      async () => new Response(JSON.stringify({ id: "msg_1" }), { status: 200 })
     )
     globalThis.fetch = mockFetch as unknown as typeof fetch
 
     const { claudeApiTrigger } = await import("../../src/triggers/claude-api")
     process.env["ANTHROPIC_API_KEY"] = "test-key"
-    await claudeApiTrigger("Hello", { api_key_env: "ANTHROPIC_API_KEY", model: "claude-sonnet-4-6" })
+    await claudeApiTrigger("Hello", {
+      api_key_env: "ANTHROPIC_API_KEY",
+      model: "claude-sonnet-4-6",
+    })
 
     expect(mockFetch).toHaveBeenCalledWith(
       "https://api.anthropic.com/v1/messages",
@@ -26,7 +29,9 @@ describe("claudeApiTrigger", () => {
   })
 
   it("throws on non-200 response", async () => {
-    globalThis.fetch = mock(async () => new Response("Unauthorized", { status: 401 })) as unknown as typeof fetch
+    globalThis.fetch = mock(
+      async () => new Response("Unauthorized", { status: 401 })
+    ) as unknown as typeof fetch
     process.env["ANTHROPIC_API_KEY"] = "bad-key"
     const { claudeApiTrigger } = await import("../../src/triggers/claude-api")
     await expect(

--- a/tests/triggers/log.test.ts
+++ b/tests/triggers/log.test.ts
@@ -9,7 +9,9 @@ describe("logTrigger", () => {
 
   it("logs a structured JSON entry with all fields", async () => {
     const logged: string[] = []
-    console.log = mock((msg: string) => { logged.push(msg) }) as typeof console.log
+    console.log = mock((msg: string) => {
+      logged.push(msg)
+    }) as typeof console.log
 
     const { logTrigger } = await import("../../src/triggers/log")
     await logTrigger("check-cron", "*/5 * * * *", "Heartbeat check")
@@ -26,7 +28,9 @@ describe("logTrigger", () => {
 
   it("logs with null prompt", async () => {
     const logged: string[] = []
-    console.log = mock((msg: string) => { logged.push(msg) }) as typeof console.log
+    console.log = mock((msg: string) => {
+      logged.push(msg)
+    }) as typeof console.log
 
     const { logTrigger } = await import("../../src/triggers/log")
     await logTrigger("check-cron", "0 9 * * 1-5", null)


### PR DESCRIPTION
- Add eslint v10, typescript-eslint v8, eslint-config-prettier, and prettier
- Configure ESLint v9 flat config with TypeScript support and underscore-prefixed unused var allowance
- Configure Prettier with no-semi, double quotes, 100 char print width
- Add format, format:check, lint, and lint:fix scripts
- Apply Prettier formatting to all existing source and test files

Closes #4